### PR TITLE
renderTosTaticMarkup now works with CDN

### DIFF
--- a/renderToStaticMarkup.js
+++ b/renderToStaticMarkup.js
@@ -1,0 +1,14 @@
+// Because once we are using the CDN version of the ReactDOMServer,
+// the function renderToStaticMarkup does not exist on ReactDOMServer
+// and render_static errors. The function does exit on the browser version
+// which might not work in Native
+let renderToStaticMarkup;
+try {
+  renderToStaticMarkup = require("react-dom/server.browser").renderToStaticMarkup;
+} catch (error) {
+  renderToStaticMarkup = require("react-dom/server").renderToStaticMarkup;
+}
+
+export {
+    renderToStaticMarkup
+}

--- a/setup-baked.js
+++ b/setup-baked.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOMServer = require('react-dom/server');
+const { renderToStaticMarkup } = require("./renderToStaticMarkup")
 
 module.exports = function(opts) {
 	const T = function (props) {
@@ -17,7 +17,7 @@ module.exports = function(opts) {
 
 	const TraksConsumer = function (props) {
 		const render_static = function (element) {
-			return ReactDOMServer.renderToStaticMarkup(element);
+			return renderToStaticMarkup(element);
 		};
 		return React.cloneElement(
 			props.children,


### PR DESCRIPTION
We are using a CDN version of react in our new build flow, and when using

`react-dom-server.browser.production.min.js`

render_static fails because it cannot load `renderTosTaticMarkup`  from `react-dom/server` as it doesn't exist.
The fix is to wrap renderTosTaticMarkup in a try and catch.

Tested on Optimeet, which heavily relies on `render_static`